### PR TITLE
Quieter terminal output

### DIFF
--- a/setup_logging.sh
+++ b/setup_logging.sh
@@ -1,13 +1,13 @@
-echo "Starting Setup Script"
-echo "---------------------"
-echo "Setting Up Logging"
-echo "---------------------"
+# 8 space indentation on echo outputs
+echo "        Setting Up Logging"
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-echo "Installing files from:"
+echo "        Installing files from:"    # SCRIPT_DIR is long so don't echo this as well on one line
+echo -n "        "  # print 8 spaces without newline at end to indent below
 echo $SCRIPT_DIR
-echo "---------------------"
-sudo apt-get install rsyslog logrotate -y
+
+sudo apt-get -qq install rsyslog logrotate -y
 
 sudo install -d -m 755 -o root -g adm /var/log/containers
 
@@ -18,6 +18,4 @@ sudo cp $SCRIPT_DIR/logrotate /etc/logrotate.d/docker
 sudo mkdir -p /etc/cron.hourly
 sudo mv /etc/cron.daily/logrotate /etc/cron.hourly/logrotate
 
-echo "---------------------"
-echo "Setup Script Complete"
-echo "---------------------"
+echo "        Setup Script Complete"

--- a/setup_logging.sh
+++ b/setup_logging.sh
@@ -7,7 +7,10 @@ echo "        Installing files from:"    # SCRIPT_DIR is long so don't echo this
 echo -n "        "  # print 8 spaces without newline at end to indent below
 echo $SCRIPT_DIR
 
-sudo apt-get -qq install rsyslog logrotate -y
+echo "        Installing rsyslog"
+sudo apt-get -qq install rsyslog -y
+echo "        Installing logrotate"
+sudo apt-get -qq install logrotate -y
 
 sudo install -d -m 755 -o root -g adm /var/log/containers
 


### PR DESCRIPTION
Clean up the terminal output when running `setup_logging.sh`. No change to usage. 

Indent all output where possible by 8 spaces. The motivation of this is consistent terminal presentation during assembly:
```
Running Service Module init scripts...
    Running init script SetupLogging/init_SM.sh
        the output of setup_logging.sh
```

Also suppress info output from `apt-get install`. Let errors stand out.
Also remove duplicated print and dashed lines which in my opinion cause the problem they are trying to solve: clutter in the terminal.