### PR TITLE
Test if daily exists before moving

### DIFF
--- a/setup_logging.sh
+++ b/setup_logging.sh
@@ -7,6 +7,7 @@ echo "        Installing files from:"    # SCRIPT_DIR is long so don't echo this
 echo -n "        "  # print 8 spaces without newline at end to indent below
 echo $SCRIPT_DIR
 
+# Install packages
 echo "        Installing rsyslog"
 sudo apt-get -qq install rsyslog -y
 echo "        Installing logrotate"
@@ -19,6 +20,10 @@ sudo systemctl restart rsyslog
 
 sudo cp $SCRIPT_DIR/logrotate /etc/logrotate.d/docker
 sudo mkdir -p /etc/cron.hourly
-sudo mv /etc/cron.daily/logrotate /etc/cron.hourly/logrotate
+
+# If /etc/cron.daily/logrotate exists, move it to hourly
+if [ -e /etc/cron.daily/logrotate ]; then
+    sudo mv /etc/cron.daily/logrotate /etc/cron.hourly/logrotate
+fi
 
 echo "        Setup Script Complete"

--- a/setup_logging.sh
+++ b/setup_logging.sh
@@ -23,6 +23,7 @@ sudo mkdir -p /etc/cron.hourly
 
 # If /etc/cron.daily/logrotate exists, move it to hourly
 if [ -e /etc/cron.daily/logrotate ]; then
+    echo "        Moving daily logrotate action to hourly"
     sudo mv /etc/cron.daily/logrotate /etc/cron.hourly/logrotate
 fi
 


### PR DESCRIPTION
Addresses #8 

Before moving a file structure, test if it exists. Only proceed to attempt move if the subject exists.

The goal of this is to not display the error `mv: cannot stat '/etc/cron.daily/logrotate': No such file or directory` when `setup_logging.sh` is run repeatedly